### PR TITLE
Fix mobile layout for main content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -30,6 +30,12 @@ body {
   align-items: start;
 }
 
+@media (max-width: 600px) {
+  .main-content {
+    grid-template-columns: 1fr;
+  }
+}
+
 .wardrobe-container {
   background: rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);


### PR DESCRIPTION
## Summary
- add responsive media query for `.main-content` so that PreviewArea and wardrobe sections stack on phones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687579761e9483289e9cd71ca9a857ca