### PR TITLE
Add race texture preview support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import NBar from './components/nbar/nbar.jsx';
 import PreviewArea from './components/preview-area/preview-area.jsx';
 import WardrobeRace from './components/wardrobe-sections/wardrobe-race.jsx';
 import skinColorMap from './data/skinColorMap.js';
+import raceTextureMap from './data/raceTextureMap.js';
 import WardrobeSkinColor from './components/wardrobe-sections/wardrobe-skincolor.jsx';
 import WardrobeEyes from './components/wardrobe-sections/wardrobe-eyes.jsx';
 import WardrobeEyescolor from './components/wardrobe-sections/wardrobe-eyescolor.jsx';
@@ -19,7 +20,7 @@ function App() {
     <div className="container">
       <NBar />
       <div className="main-content">
-        <PreviewArea />
+        <PreviewArea texture={raceTextureMap[race]} />
         <div className="wardrobe-container">
           <WardrobeRace
             onChange={(selected) => {

--- a/src/components/preview-area/preview-area.jsx
+++ b/src/components/preview-area/preview-area.jsx
@@ -1,11 +1,11 @@
 import ThreePreview from '../three/three-preview';
 import './preview-area.css';
 
-function PreviewArea() {
+function PreviewArea({ texture }) {
   return (
     <div className="preview-area">
       <div className="character-preview">
-        <ThreePreview />
+        <ThreePreview texture={texture} />
       </div>
       <div className="action-buttons">
         <button className="btn btn-primary">Download Skin</button>

--- a/src/components/three/three-preview.jsx
+++ b/src/components/three/three-preview.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
-export default function ThreePreview() {
+export default function ThreePreview({ texture }) {
   const containerRef = useRef();
 
   useEffect(() => {
@@ -30,14 +30,14 @@ export default function ThreePreview() {
     group.position.y = -10;
 
     const loader = new THREE.TextureLoader();
-    loader.load('/textures/steve.png', (texture) => {
-      texture.magFilter = THREE.NearestFilter;
-      texture.minFilter = THREE.NearestFilter;
+    loader.load(texture || '/textures/steve.png', (tex) => {
+      tex.magFilter = THREE.NearestFilter;
+      tex.minFilter = THREE.NearestFilter;
 
       const texSize = 64;
 
       const setUV = (mat, rect) => {
-        mat.map = texture.clone();
+        mat.map = tex.clone();
         mat.map.magFilter = THREE.NearestFilter;
         mat.map.minFilter = THREE.NearestFilter;
         mat.map.repeat.set((rect[2] - rect[0]) / texSize, (rect[3] - rect[1]) / texSize);
@@ -125,7 +125,7 @@ export default function ThreePreview() {
       renderer.dispose();
       container.innerHTML = '';
     };
-  }, []);
+  }, [texture]);
 
   return (
     <div

--- a/src/data/raceTextureMap.js
+++ b/src/data/raceTextureMap.js
@@ -1,0 +1,6 @@
+const raceTextureMap = {
+  Human: '/textures/race/human.png',
+  Orc: '/textures/race/orc.png',
+};
+
+export default raceTextureMap;


### PR DESCRIPTION
## Summary
- map races to texture paths
- pass selected race texture to preview area
- load texture in Three.js preview based on selection

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68762c2b379c83289ff2b4ff17916e9a