### PR TITLE
Add pose selection in preview

### DIFF
--- a/src/components/preview-area/preview-area.jsx
+++ b/src/components/preview-area/preview-area.jsx
@@ -1,13 +1,23 @@
 import ThreePreview from '../three/three-preview';
 import './preview-area.css';
+import { useState } from 'react';
 
 function PreviewArea({ texture }) {
+  const [pose, setPose] = useState('default');
+
+  const cyclePose = () => {
+    setPose((p) => (p === 'default' ? 'tpose' : p === 'tpose' ? 'walking' : 'default'));
+  };
+
   return (
     <div className="preview-area">
       <div className="character-preview">
-        <ThreePreview texture={texture} />
+        <ThreePreview texture={texture} pose={pose} />
       </div>
       <div className="action-buttons">
+        <button className="btn btn-secondary" onClick={cyclePose}>
+          Change Pose
+        </button>
         <button className="btn btn-primary">Download Skin</button>
       </div>
     </div>

--- a/src/components/three/three-preview.jsx
+++ b/src/components/three/three-preview.jsx
@@ -1,8 +1,51 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
-export default function ThreePreview({ texture }) {
+export default function ThreePreview({ texture, pose = 'default' }) {
   const containerRef = useRef();
+  const armLRef = useRef();
+  const armRRef = useRef();
+  const legLRef = useRef();
+  const legRRef = useRef();
+  const armLOLRef = useRef();
+  const armROLRef = useRef();
+  const legLOLRef = useRef();
+  const legROLRef = useRef();
+
+  const applyPose = (p) => {
+    const armL = armLRef.current;
+    const armR = armRRef.current;
+    const legL = legLRef.current;
+    const legR = legRRef.current;
+    const armLOL = armLOLRef.current;
+    const armROL = armROLRef.current;
+    const legLOL = legLOLRef.current;
+    const legROL = legROLRef.current;
+
+    if (!armL || !armR || !legL || !legR) return;
+
+    [armL, armR, legL, legR, armLOL, armROL, legLOL, legROL].forEach((part) => {
+      if (part) part.rotation.set(0, 0, 0);
+    });
+
+    if (p === 'tpose') {
+      if (armL) armL.rotation.z = Math.PI / 2;
+      if (armR) armR.rotation.z = -Math.PI / 2;
+      if (armLOL) armLOL.rotation.z = Math.PI / 2;
+      if (armROL) armROL.rotation.z = -Math.PI / 2;
+    } else if (p === 'walking') {
+      const forward = -Math.PI / 4;
+      const backward = Math.PI / 4;
+      if (armL) armL.rotation.x = forward;
+      if (armR) armR.rotation.x = backward;
+      if (legL) legL.rotation.x = backward;
+      if (legR) legR.rotation.x = forward;
+      if (armLOL) armLOL.rotation.x = forward;
+      if (armROL) armROL.rotation.x = backward;
+      if (legLOL) legLOL.rotation.x = backward;
+      if (legROL) legROL.rotation.x = forward;
+    }
+  };
 
   useEffect(() => {
     const container = containerRef.current;
@@ -148,6 +191,11 @@ export default function ThreePreview({ texture }) {
       const legL = createBox(4, 12, 4, -2, 0, 0, legMap);
       const legR = createBox(4, 12, 4, 2, 0, 0, legMap);
 
+      armLRef.current = armL;
+      armRRef.current = armR;
+      legLRef.current = legL;
+      legRRef.current = legR;
+
       const headOL = createBox(8, 8, 8, 0, 22, 0, headOverlayMap, {
         transparent: true,
         expand: 0.5,
@@ -173,20 +221,14 @@ export default function ThreePreview({ texture }) {
         expand: 0.5,
       });
 
-      group.add(
-        head,
-        body,
-        armL,
-        armR,
-        legL,
-        legR,
-        headOL,
-        bodyOL,
-        armLOL,
-        armROL,
-        legLOL,
-        legROL
-      );
+      armLOLRef.current = armLOL;
+      armROLRef.current = armROL;
+      legLOLRef.current = legLOL;
+      legROLRef.current = legROL;
+
+      group.add(head, body, armL, armR, legL, legR, headOL, bodyOL, armLOL, armROL, legLOL, legROL);
+
+      applyPose(pose);
     });
 
     const animate = () => {
@@ -201,6 +243,10 @@ export default function ThreePreview({ texture }) {
       container.innerHTML = '';
     };
   }, [texture]);
+
+  useEffect(() => {
+    applyPose(pose);
+  }, [pose]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- add 'Change Pose' button to toggle between default, t-pose and walking poses
- implement pose logic in `ThreePreview` and update preview

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687699abd73c8328b754e217557a281a