### PR TITLE
Fix overlay limb walking pose positions

### DIFF
--- a/src/components/three/three-preview.jsx
+++ b/src/components/three/three-preview.jsx
@@ -25,8 +25,19 @@ export default function ThreePreview({ texture, pose = 'default' }) {
     if (!armL || !armR || !legL || !legR) return;
 
     [armL, armR, legL, legR, armLOL, armROL, legLOL, legROL].forEach((part) => {
-      if (part) part.rotation.set(0, 0, 0);
+      if (part) {
+        part.rotation.set(0, 0, 0);
+      }
     });
+
+    if (armL) armL.position.set(-6, 12, 0);
+    if (armR) armR.position.set(6, 12, 0);
+    if (legL) legL.position.set(-2, 0, 0);
+    if (legR) legR.position.set(2, 0, 0);
+    if (armLOL) armLOL.position.set(-6, 12, 0);
+    if (armROL) armROL.position.set(6, 12, 0);
+    if (legLOL) legLOL.position.set(-2, 0, 0);
+    if (legROL) legROL.position.set(2, 0, 0);
 
     if (p === 'tpose') {
       if (armL) armL.rotation.z = Math.PI / 2;
@@ -54,10 +65,24 @@ export default function ThreePreview({ texture, pose = 'default' }) {
         legR.position.z = 4;
         legR.position.y = 1;
       }
-      if (armLOL) armLOL.rotation.x = forward;
-      if (armROL) armROL.rotation.x = backward;
-      if (legLOL) legLOL.rotation.x = backward;
-      if (legROL) legROL.rotation.x = forward;
+      if (armLOL) {
+        armLOL.rotation.x = forward;
+        armLOL.position.z = 3;
+      }
+      if (armROL) {
+        armROL.rotation.x = backward;
+        armROL.position.z = -3;
+      }
+      if (legLOL) {
+        legLOL.rotation.x = backward;
+        legLOL.position.z = -4;
+        legLOL.position.y = 1;
+      }
+      if (legROL) {
+        legROL.rotation.x = forward;
+        legROL.position.z = 4;
+        legROL.position.y = 1;
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- reset part positions before applying a new pose
- move overlay limbs with main limbs during walking

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6876a1794a84832880f11a3b5757027a