### PR TITLE
Add overlay toggle button

### DIFF
--- a/src/components/preview-area/preview-area.jsx
+++ b/src/components/preview-area/preview-area.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 function PreviewArea({ texture }) {
   const [pose, setPose] = useState('default');
+  const [showOverlay, setShowOverlay] = useState(true);
 
   const cyclePose = () => {
     setPose((p) => (p === 'default' ? 'tpose' : p === 'tpose' ? 'walking' : 'default'));
@@ -12,11 +13,17 @@ function PreviewArea({ texture }) {
   return (
     <div className="preview-area">
       <div className="character-preview">
-        <ThreePreview texture={texture} pose={pose} />
+        <ThreePreview texture={texture} pose={pose} showOverlay={showOverlay} />
       </div>
       <div className="action-buttons">
         <button className="btn btn-secondary" onClick={cyclePose}>
           Change Pose
+        </button>
+        <button
+          className="btn btn-secondary"
+          onClick={() => setShowOverlay((v) => !v)}
+        >
+          {showOverlay ? 'Hide' : 'Show'} Overlay
         </button>
         <button className="btn btn-primary">Download Skin</button>
       </div>

--- a/src/components/three/three-preview.jsx
+++ b/src/components/three/three-preview.jsx
@@ -13,7 +13,7 @@ import {
   legOverlayMap,
 } from './skin-maps';
 
-export default function ThreePreview({ texture, pose = 'default' }) {
+export default function ThreePreview({ texture, pose = 'default', showOverlay = true }) {
   const containerRef = useRef();
   const armLRef = useRef();
   const armRRef = useRef();
@@ -23,6 +23,17 @@ export default function ThreePreview({ texture, pose = 'default' }) {
   const armROLRef = useRef();
   const legLOLRef = useRef();
   const legROLRef = useRef();
+  const headOLRef = useRef();
+  const bodyOLRef = useRef();
+
+  const overlayRefs = [
+    headOLRef,
+    bodyOLRef,
+    armLOLRef,
+    armROLRef,
+    legLOLRef,
+    legROLRef,
+  ];
 
   const applyPoseLocal = (p) =>
     applyPose(p, {
@@ -103,12 +114,20 @@ export default function ThreePreview({ texture, pose = 'default' }) {
         expand: 0.5,
       });
 
+      headOLRef.current = headOL;
+      bodyOLRef.current = bodyOL;
       armLOLRef.current = armLOL;
       armROLRef.current = armROL;
       legLOLRef.current = legLOL;
       legROLRef.current = legROL;
 
       group.add(head, body, armL, armR, legL, legR, headOL, bodyOL, armLOL, armROL, legLOL, legROL);
+
+      overlayRefs.forEach((ref) => {
+        if (ref.current) {
+          ref.current.visible = showOverlay;
+        }
+      });
 
       applyPoseLocal(pose);
     });
@@ -129,6 +148,14 @@ export default function ThreePreview({ texture, pose = 'default' }) {
   useEffect(() => {
     applyPoseLocal(pose);
   }, [pose]);
+
+  useEffect(() => {
+    overlayRefs.forEach((ref) => {
+      if (ref.current) {
+        ref.current.visible = showOverlay;
+      }
+    });
+  }, [showOverlay]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- allow toggling overlay skin pieces in `ThreePreview`
- provide button in the preview area to show/hide overlay parts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876acb9431c8328bfc6e7966ff2717c