### PR TITLE
Fix mirror for left hand and leg

### DIFF
--- a/src/components/three/create-box.js
+++ b/src/components/three/create-box.js
@@ -18,6 +18,8 @@ export default function createBox(tex, w, h, d, x, y, z, uvMap, options = {}) {
     mat.map = tex.clone();
     mat.map.magFilter = THREE.NearestFilter;
     mat.map.minFilter = THREE.NearestFilter;
+    mat.map.wrapS = THREE.RepeatWrapping;
+    mat.map.wrapT = THREE.RepeatWrapping;
     mat.map.repeat.set((rect[2] - rect[0]) / TEX_SIZE, (rect[3] - rect[1]) / TEX_SIZE);
     mat.map.offset.set(rect[0] / TEX_SIZE, 1 - rect[3] / TEX_SIZE);
     mat.map.needsUpdate = true;

--- a/src/components/three/skin-maps.js
+++ b/src/components/three/skin-maps.js
@@ -69,3 +69,27 @@ export const legOverlayMap = {
   front: [4, 36, 8, 48],
   back: [12, 36, 16, 48],
 };
+
+export const leftArmMap = {
+  ...armMap,
+  front: [armMap.front[2], armMap.front[1], armMap.front[0], armMap.front[3]],
+  back: [armMap.back[2], armMap.back[1], armMap.back[0], armMap.back[3]],
+};
+
+export const leftLegMap = {
+  ...legMap,
+  front: [legMap.front[2], legMap.front[1], legMap.front[0], legMap.front[3]],
+  back: [legMap.back[2], legMap.back[1], legMap.back[0], legMap.back[3]],
+};
+
+export const leftArmOverlayMap = {
+  ...armOverlayMap,
+  front: [armOverlayMap.front[2], armOverlayMap.front[1], armOverlayMap.front[0], armOverlayMap.front[3]],
+  back: [armOverlayMap.back[2], armOverlayMap.back[1], armOverlayMap.back[0], armOverlayMap.back[3]],
+};
+
+export const leftLegOverlayMap = {
+  ...legOverlayMap,
+  front: [legOverlayMap.front[2], legOverlayMap.front[1], legOverlayMap.front[0], legOverlayMap.front[3]],
+  back: [legOverlayMap.back[2], legOverlayMap.back[1], legOverlayMap.back[0], legOverlayMap.back[3]],
+};

--- a/src/components/three/three-preview.jsx
+++ b/src/components/three/three-preview.jsx
@@ -11,6 +11,10 @@ import {
   bodyOverlayMap,
   armOverlayMap,
   legOverlayMap,
+  leftArmMap,
+  leftLegMap,
+  leftArmOverlayMap,
+  leftLegOverlayMap,
 } from './skin-maps';
 
 export default function ThreePreview({ texture, pose = 'default', showOverlay = true }) {
@@ -79,9 +83,9 @@ export default function ThreePreview({ texture, pose = 'default', showOverlay = 
 
       const head = createBox(tex, 8, 8, 8, 0, 22, 0, headMap);
       const body = createBox(tex, 8, 12, 4, 0, 12, 0, bodyMap);
-      const armL = createBox(tex, 4, 12, 4, -6, 12, 0, armMap);
+      const armL = createBox(tex, 4, 12, 4, -6, 12, 0, leftArmMap);
       const armR = createBox(tex, 4, 12, 4, 6, 12, 0, armMap);
-      const legL = createBox(tex, 4, 12, 4, -2, 0, 0, legMap);
+      const legL = createBox(tex, 4, 12, 4, -2, 0, 0, leftLegMap);
       const legR = createBox(tex, 4, 12, 4, 2, 0, 0, legMap);
 
       armLRef.current = armL;
@@ -97,7 +101,7 @@ export default function ThreePreview({ texture, pose = 'default', showOverlay = 
         transparent: true,
         expand: 0.5,
       });
-      const armLOL = createBox(tex, 4, 12, 4, -6, 12, 0, armOverlayMap, {
+      const armLOL = createBox(tex, 4, 12, 4, -6, 12, 0, leftArmOverlayMap, {
         transparent: true,
         expand: 0.5,
       });
@@ -105,7 +109,7 @@ export default function ThreePreview({ texture, pose = 'default', showOverlay = 
         transparent: true,
         expand: 0.5,
       });
-      const legLOL = createBox(tex, 4, 12, 4, -2, 0, 0, legOverlayMap, {
+      const legLOL = createBox(tex, 4, 12, 4, -2, 0, 0, leftLegOverlayMap, {
         transparent: true,
         expand: 0.5,
       });


### PR DESCRIPTION
## Summary
- support negative UV repeat values in `create-box.js`
- add mirrored UV maps for left arm and leg
- use mirrored maps when building the model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876b26f3d9083288cdb9c9ff2974a66