### PR TITLE
Add React Router for skin viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# SkinCrafter
+
+SkinCrafter is a small React application for previewing Minecraft skins. The preview uses Three.js and React Router to display the model in 3D across multiple pages.
+
+## Running locally
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:5173` by default.
+Navigate to `/` for the wardrobe interface or `/mcskinview` to view skins from the Mojang API.
+
+## Loading a Minecraft skin
+
+Open `/mcskinview` to load a skin by entering a Minecraft username. The page contacts the Mojang APIs to retrieve the player's skin and shows it in the 3D preview.
+
+If the user cannot be found or the profile is missing a skin, an error message will be displayed.
+
+## Build
+
+To create a production build run:
+
+```bash
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "three": "^0.178.0"
+    "three": "^0.178.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.1.0",

--- a/src/McSkinView.jsx
+++ b/src/McSkinView.jsx
@@ -1,0 +1,45 @@
+import './App.css';
+import { useState } from 'react';
+import fetchSkin from './api/fetchSkin.js';
+import NBar from './components/nbar/nbar.jsx';
+import PreviewArea from './components/preview-area/preview-area.jsx';
+
+function McSkinView() {
+  const [username, setUsername] = useState('');
+  const [texture, setTexture] = useState(null);
+  const [error, setError] = useState(null);
+
+  return (
+    <div className="container">
+      <NBar />
+      <div className="main-content">
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            setError(null);
+            try {
+              const url = await fetchSkin(username);
+              setTexture(url);
+            } catch (err) {
+              setError(err.message);
+              setTexture(null);
+            }
+          }}
+          style={{ marginBottom: '1rem' }}
+        >
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Minecraft username"
+          />
+          <button type="submit">Load Skin</button>
+        </form>
+        {error && <div className="error-message">{error}</div>}
+        <PreviewArea texture={texture} />
+      </div>
+    </div>
+  );
+}
+
+export default McSkinView;

--- a/src/api/fetchSkin.js
+++ b/src/api/fetchSkin.js
@@ -1,0 +1,22 @@
+export default async function fetchSkin(username) {
+  const profileRes = await fetch(
+    `https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(username)}`
+  );
+  if (!profileRes.ok) {
+    throw new Error('User not found');
+  }
+  const profile = await profileRes.json();
+  const sessionRes = await fetch(
+    `https://sessionserver.mojang.com/session/minecraft/profile/${profile.id}`
+  );
+  if (!sessionRes.ok) {
+    throw new Error('Failed to fetch profile');
+  }
+  const sessionProfile = await sessionRes.json();
+  const texturesProp = sessionProfile.properties.find((p) => p.name === 'textures');
+  if (!texturesProp) {
+    throw new Error('Skin texture not found');
+  }
+  const decoded = JSON.parse(atob(texturesProp.value));
+  return decoded.textures.SKIN.url;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import App from './App';
+import McSkinView from './McSkinView.jsx';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
+
 root.render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="/mcskinview" element={<McSkinView />} />
+      </Routes>
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency
- use React Router in `main.jsx` to route `/` and `/mcskinview`
- document navigation in README

## Testing
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68779aed1f188328a25d8961e9187fbf