### PR TITLE
Add Jest config and test script

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  },
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.js']
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "sitemap": "node generate-sitemap.js",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
-    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
+    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -22,6 +23,10 @@
     "@vitejs/plugin-react": "^4.1.0",
     "gh-pages": "^6.3.0",
     "prettier": "^3.6.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/jest-dom": "^6.1.6",
+    "babel-jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest config using jsdom
- set up Babel transform for ESM
- add Jest, React Testing Library, and babel-jest as dev dependencies
- expose `npm test` script

## Testing
- `npm install --save-dev jest @testing-library/react @testing-library/jest-dom babel-jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68781156241083289cc41dc00ade90ec