### PR TITLE
Fix NPM integrity hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1914,7 +1914,7 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.26.0"


### PR DESCRIPTION
## Summary
- adjust `react-dom` integrity string in package-lock.json

## Testing
- `npm install` *(fails: 403 Forbidden due to disabled network)*

------
https://chatgpt.com/codex/tasks/task_e_68797a35362883289a9cfa2f8cfb87a3