### PR TITLE
Add typed interfaces in fetchSkin

### DIFF
--- a/src/api/fetchSkin.ts
+++ b/src/api/fetchSkin.ts
@@ -1,22 +1,44 @@
-export default async function fetchSkin(username) {
+interface MojangProfile {
+  id: string;
+  name: string;
+}
+
+interface SessionProfileProperty {
+  name: string;
+  value: string;
+}
+
+interface MojangSessionProfile {
+  properties: SessionProfileProperty[];
+}
+
+interface DecodedTextures {
+  textures: {
+    SKIN: {
+      url: string;
+    };
+  };
+}
+
+export default async function fetchSkin(username: string): Promise<string> {
   const profileRes = await fetch(
     `https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(username)}`
   );
   if (!profileRes.ok) {
     throw new Error('User not found');
   }
-  const profile = await profileRes.json();
+  const profile: MojangProfile = await profileRes.json();
   const sessionRes = await fetch(
     `https://sessionserver.mojang.com/session/minecraft/profile/${profile.id}`
   );
   if (!sessionRes.ok) {
     throw new Error('Failed to fetch profile');
   }
-  const sessionProfile = await sessionRes.json();
+  const sessionProfile: MojangSessionProfile = await sessionRes.json();
   const texturesProp = sessionProfile.properties.find((p) => p.name === 'textures');
   if (!texturesProp) {
     throw new Error('Skin texture not found');
   }
-  const decoded = JSON.parse(atob(texturesProp.value));
+  const decoded: DecodedTextures = JSON.parse(atob(texturesProp.value));
   return decoded.textures.SKIN.url;
 }


### PR DESCRIPTION
## Summary
- add Mojang API interface definitions
- type fetchSkin parameters and return value

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687a5d2bf0f083289ea0f0cedfeca4f4