### PR TITLE
Rename eyes color component

### DIFF
--- a/src/components/wardrobe-sections/WardrobeEyesColor.tsx
+++ b/src/components/wardrobe-sections/WardrobeEyesColor.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './wardrobe.css';
+
+function WardrobeEyesColor(): JSX.Element {
+  return <div>{WardrobeEyesColor.name}</div>;
+}
+
+export default WardrobeEyesColor;

--- a/src/components/wardrobe-sections/wardrobe-eyescolor.tsx
+++ b/src/components/wardrobe-sections/wardrobe-eyescolor.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import './wardrobe.css';
-
-function WardrobeEyescolor(): React.JSX.Element {
-  return <div>{WardrobeEyescolor.name}</div>;
-}
-
-export default WardrobeEyescolor;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -9,7 +9,7 @@ import PreviewArea from '../components/preview-area/preview-area';
 import WardrobeRace from '../components/wardrobe-sections/wardrobe-race';
 import WardrobeSkinColor from '../components/wardrobe-sections/wardrobe-skincolor';
 import WardrobeEyes from '../components/wardrobe-sections/wardrobe-eyes';
-import WardrobeEyesColor from '../components/wardrobe-sections/wardrobe-eyescolor';
+import WardrobeEyesColor from '../components/wardrobe-sections/WardrobeEyesColor';
 
 import skinColorMap from '../data/skinColorMap';
 import raceTextureMap from '../data/raceTextureMap';


### PR DESCRIPTION
## Summary
- rename `wardrobe-eyescolor.tsx` to `WardrobeEyesColor.tsx`
- rename component to `WardrobeEyesColor` and return `JSX.Element`
- fix imports referencing the new component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5d3f2b0c832895b97aaf276c5eb6