### PR TITLE
Fix animation cleanup

### DIFF
--- a/src/components/three/three-preview.tsx
+++ b/src/components/three/three-preview.tsx
@@ -154,8 +154,9 @@ export default function ThreePreview({
       applyPoseLocal(pose);
     });
 
+    let animationFrameId: number;
     const animate = () => {
-      requestAnimationFrame(animate);
+      animationFrameId = requestAnimationFrame(animate);
       group.rotation.y += 0.01;
       renderer.render(scene, camera);
     };
@@ -177,6 +178,7 @@ export default function ThreePreview({
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      cancelAnimationFrame(animationFrameId);
       renderer.dispose();
       if (renderer.domElement.parentNode) {
         renderer.domElement.parentNode.removeChild(renderer.domElement);


### PR DESCRIPTION
## Summary
- store the ID from `requestAnimationFrame`
- cancel the animation loop on cleanup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a662d6dd48328a0048b60598a4aae