### PR TITLE
Clean up sitemap handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ To create a production build run:
 ```bash
 npm run build
 ```
+
+## Sitemap
+
+Generate `public/sitemap.xml` whenever new routes are added so search engines can
+index the site correctly:
+
+```bash
+npm run sitemap
+```

--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -1,6 +1,10 @@
 const Sitemap = require("react-router-sitemap").default;
 const path = require("path");
 
+// Write the generated sitemap to the `public` folder so Vite copies it to the
+// site root during the build step.
+const sitemapOutput = path.resolve(__dirname, "public", "sitemap.xml");
+
 const sitemap = new Sitemap(path.resolve(__dirname, "./src/App.tsx"))
   .build("https://skincrafter.dihor.pl")
-  .save(path.resolve(__dirname, "./public/sitemap.xml"));
+  .save(sitemapOutput);

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://skincrafter.dihor.pl/</loc>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>


### PR DESCRIPTION
## Summary
- remove old `sitemap.xml`
- clarify sitemap output path in `generate-sitemap.js`
- document how to regenerate the sitemap

## Testing
- `npm run sitemap` *(fails: Cannot find module 'react-router-sitemap')*

------
https://chatgpt.com/codex/tasks/task_e_687a662e3c50832890b515bb2493e1bf