### PR TITLE
Fix env values on build

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 interface ImportMetaEnv {
   readonly DEV: boolean;
   readonly PROD: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["src", "node_modules/@types"]
+    "typeRoots": ["src", "node_modules/@types"],
+    "types": ["vite/client"]
   },
   "include": ["src", "src/env.d.ts"],
   "exclude": ["node_modules"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
   server: {
     host: true,
   },
-});
+  define: {
+    'import.meta.env.DEV': mode !== 'production',
+    'import.meta.env.PROD': mode === 'production',
+  },
+}));


### PR DESCRIPTION
## Summary
- ensure Vite env typings are loaded
- define `import.meta.env` values based on build mode

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfb40d0088328a8808abc80274bdc