### PR TITLE
Add under construction banner

### DIFF
--- a/src/components/UnderConstructionBanner.css
+++ b/src/components/UnderConstructionBanner.css
@@ -1,0 +1,8 @@
+.under-construction-banner {
+  background: var(--wow-red);
+  color: var(--wow-dark-gold);
+  text-align: center;
+  padding: 8px 0;
+  font-weight: bold;
+  box-shadow: 0 2px 10px var(--wow-shadow);
+}

--- a/src/components/UnderConstructionBanner.tsx
+++ b/src/components/UnderConstructionBanner.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import './UnderConstructionBanner.css';
+
+export default function UnderConstructionBanner(): React.JSX.Element {
+  return (
+    <div className="under-construction-banner" role="status">
+      Site under construction
+    </div>
+  );
+}

--- a/src/pages/App.css
+++ b/src/pages/App.css
@@ -1,6 +1,6 @@
 .container {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto auto 1fr;
   min-height: 100vh;
   gap: 30px;
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 
 import { Race } from '../data/races';
 import NBar from '../components/nbar/NBar';
+import UnderConstructionBanner from '../components/UnderConstructionBanner';
 import PreviewArea from '../components/preview-area/PreviewArea';
 import WardrobeRace from '../components/wardrobe-sections/WardrobeRace';
 import WardrobeSkinColor from '../components/wardrobe-sections/WardrobeSkinColor';
@@ -73,6 +74,7 @@ const App: React.FC = () => {
     <div className="container">
       <div className="particles" ref={particlesRef} />
       <NBar />
+      <UnderConstructionBanner />
 
       <div className="main-content">
         <PreviewArea texture={combinedTexture} />

--- a/src/pages/McSkinView.tsx
+++ b/src/pages/McSkinView.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import fetchSkin from '../api/fetchSkin';
 import NBar from '../components/nbar/NBar';
 import PreviewArea from '../components/preview-area/PreviewArea';
+import UnderConstructionBanner from '../components/UnderConstructionBanner';
 
 const McSkinView: React.FC = () => {
   const [username, setUsername] = useState<string>('');
@@ -45,6 +46,7 @@ const McSkinView: React.FC = () => {
   return (
     <div className="container">
       <NBar />
+      <UnderConstructionBanner />
       <div className="main-content">
         <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
           <input


### PR DESCRIPTION
## Summary
- show a short red "Site under construction" banner below the navigation bar
- adjust layout grid to fit new banner

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_687d07618a608328b1f2187fc00ad318