### PR TITLE
Align navbar logo and update banner color

### DIFF
--- a/src/components/UnderConstructionBanner.css
+++ b/src/components/UnderConstructionBanner.css
@@ -1,6 +1,6 @@
 .under-construction-banner {
   background: var(--wow-red);
-  color: var(--wow-dark-gold);
+  color: #fff;
   text-align: center;
   padding: 8px 0;
   font-weight: bold;

--- a/src/components/nbar/NBar.css
+++ b/src/components/nbar/NBar.css
@@ -2,8 +2,10 @@
   background: linear-gradient(90deg, var(--wow-dark-blue), var(--wow-medium-blue));
   border-bottom: 3px solid var(--wow-gold);
   box-shadow: 0 4px 20px var(--wow-shadow);
-  padding: 15px 0;
+  padding: 15px 20px;
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .navbar::before {
@@ -28,7 +30,7 @@
 }
 
 .logo-container {
-  text-align: center;
+  margin-right: auto;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- tweak banner colors for UnderConstructionBanner
- left-align the logo in `NBar`

## Testing
- `npm run format`
- `npm run lint` *(fails: A config object is using the "parser" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_687d091f32188328afa9e65863e13003