### PR TITLE
Add selectable forest theme

### DIFF
--- a/src/components/nbar/NBar.css
+++ b/src/components/nbar/NBar.css
@@ -39,3 +39,11 @@
   image-rendering: pixelated;
   image-rendering: crisp-edges;
 }
+
+.theme-select {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--wow-bronze);
+  background: var(--wow-light-blue);
+  color: var(--wow-gold);
+}

--- a/src/components/nbar/NBar.tsx
+++ b/src/components/nbar/NBar.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './NBar.css';
+
+type Theme = 'wow' | 'forest';
 
 interface NBarProps {
   logoSrc?: string;
@@ -7,18 +9,36 @@ interface NBarProps {
 }
 
 const NBar: React.FC<NBarProps> = ({ logoSrc = '/logo.png', logoAlt = 'Logo aplikacji' }) => {
+  const [theme, setTheme] = useState<Theme>('wow');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved === 'forest') {
+      setTheme('forest');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.remove('theme-wow', 'theme-forest');
+    document.body.classList.add(`theme-${theme}`);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
   return (
     <nav className="navbar" role="navigation" aria-label="Główna nawigacja">
       <div className="logo-container">
         <img src={logoSrc} alt={logoAlt} className="logo" draggable={false} />
       </div>
       <div className="nav-links">
-        {/* <a href="#" className="nav-link" aria-label="Pomoc">
-          Help
-        </a>
-        <a href="#" className="nav-coffee-btn" aria-label="Kup mi kawę">
-          Buy me a coffee
-        </a> */}
+        <select
+          aria-label="Select theme"
+          className="theme-select"
+          value={theme}
+          onChange={(e) => setTheme(e.target.value as Theme)}
+        >
+          <option value="wow">Default</option>
+          <option value="forest">Forest</option>
+        </select>
       </div>
     </nav>
   );

--- a/src/components/nbar/Nbar.tsx
+++ b/src/components/nbar/Nbar.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './NBar.css';
+
+type Theme = 'wow' | 'forest';
 
 interface NBarProps {
   logoSrc?: string;
@@ -7,18 +9,36 @@ interface NBarProps {
 }
 
 const NBar: React.FC<NBarProps> = ({ logoSrc = '/logo.png', logoAlt = 'Logo aplikacji' }) => {
+  const [theme, setTheme] = useState<Theme>('wow');
+
+  useEffect(() => {
+    const saved = localStorage.getItem('theme') as Theme | null;
+    if (saved === 'forest') {
+      setTheme('forest');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.remove('theme-wow', 'theme-forest');
+    document.body.classList.add(`theme-${theme}`);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
   return (
     <nav className="navbar" role="navigation" aria-label="Główna nawigacja">
       <div className="logo-container">
         <img src={logoSrc} alt={logoAlt} className="logo" draggable={false} />
       </div>
       <div className="nav-links">
-        {/* <a href="#" className="nav-link" aria-label="Pomoc">
-          Help
-        </a>
-        <a href="#" className="nav-coffee-btn" aria-label="Kup mi kawę">
-          Buy me a coffee
-        </a> */}
+        <select
+          aria-label="Select theme"
+          className="theme-select"
+          value={theme}
+          onChange={(e) => setTheme(e.target.value as Theme)}
+        >
+          <option value="wow">Default</option>
+          <option value="forest">Forest</option>
+        </select>
       </div>
     </nav>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,21 @@
   --wow-shadow: rgba(0, 0, 0, 0.8);
 }
 
+body.theme-forest {
+  --wow-gold: #d4af37;
+  --wow-dark-gold: #f4e781;
+  --wow-bronze: #8b6914;
+  --wow-dark-blue: #1a2b1a;
+  --wow-medium-blue: #2d4a2d;
+  --wow-light-blue: #3d5f3d;
+  --wow-purple: #4a6741;
+  --wow-green: #87a96b;
+  --wow-red: #ffbf00;
+  --wow-stone: #4b3621;
+  --wow-stone-light: #6b4a2a;
+  --wow-shadow: rgba(15, 25, 15, 0.8);
+}
+
 * {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- add alternate forest color palette in CSS
- allow picking theme in navbar and store selection in localStorage
- style the theme selector

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d0b6bbc608328803f4baf76bc83ee