### PR TITLE
Add under construction notice to navbar

### DIFF
--- a/src/components/nbar/NBar.css
+++ b/src/components/nbar/NBar.css
@@ -74,3 +74,8 @@
 .nav-coffee-btn::before {
   content: '☕';
 }
+
+.under-construction {
+  color: #ff4d4d;
+  font-weight: bold;
+}

--- a/src/components/nbar/NBar.tsx
+++ b/src/components/nbar/NBar.tsx
@@ -13,6 +13,7 @@ const NBar: React.FC<NBarProps> = ({ logoSrc = '/logo.png', logoAlt = 'Logo apli
         <img src={logoSrc} alt={logoAlt} className="logo" draggable={false} />
       </div>
       <div className="nav-links">
+        <span className="under-construction">Under Construction</span>
         {/* <a href="#" className="nav-link" aria-label="Pomoc">
           Help
         </a>

--- a/src/components/nbar/Nbar.tsx
+++ b/src/components/nbar/Nbar.tsx
@@ -13,6 +13,7 @@ const NBar: React.FC<NBarProps> = ({ logoSrc = '/logo.png', logoAlt = 'Logo apli
         <img src={logoSrc} alt={logoAlt} className="logo" draggable={false} />
       </div>
       <div className="nav-links">
+        <span className="under-construction">Under Construction</span>
         {/* <a href="#" className="nav-link" aria-label="Pomoc">
           Help
         </a>


### PR DESCRIPTION
## Summary
- add visual notice in navbar showing app is under construction

## Testing
- `npm run lint` *(fails: A config object is using the `parser` key, which is not supported in flat config system)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea1df69108328a1853c6d2fa3cb2a