### PR TITLE
Fix preview width resizing

### DIFF
--- a/src/components/three/three-preview.tsx
+++ b/src/components/three/three-preview.tsx
@@ -173,11 +173,15 @@ export default function ThreePreview({
       }
     };
 
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(container);
+
     window.addEventListener('resize', handleResize);
     handleResize(); // Initial sizing
 
     return () => {
       window.removeEventListener('resize', handleResize);
+      resizeObserver.disconnect();
       cancelAnimationFrame(animationFrameId);
       rotationRef.current = group.rotation.y;
       renderer.dispose();

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -53,10 +53,10 @@ const App: React.FC = () => {
       <NBar />
 
       <div className="flex-1 flex flex-col md:flex-row gap-8">
-        <div className="flex-1">
+        <div className="flex-1 w-full md:w-1/2">
           <PreviewArea texture={combinedTexture} />
         </div>
-        <div className="flex-1">
+        <div className="flex-1 w-full md:w-1/2">
           <Wardrobe
             skinColors={skinColors}
             selectedSkinColor={skinColor}


### PR DESCRIPTION
## Summary
- observe preview container resize so the canvas adjusts width
- enforce 50/50 layout for PreviewArea and Wardrobe on desktop

## Testing
- `npx prettier -w src/components/three/three-preview.tsx src/pages/App.tsx`

------
https://chatgpt.com/codex/tasks/task_e_687f9df7e4bc83288b57a202e16fc76f