### PR TITLE
Fix preview height

### DIFF
--- a/src/components/previewArea.tsx
+++ b/src/components/previewArea.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import ThreePreview from './three/three-preview';
 import type { Pose } from './three/pose-utils';
 
@@ -9,6 +9,8 @@ interface PreviewAreaProps {
 export default function PreviewArea({ texture }: PreviewAreaProps): React.JSX.Element {
   const [pose, setPose] = useState<Pose>('default');
   const [showOverlay, setShowOverlay] = useState<boolean>(true);
+  const [offset, setOffset] = useState<number>(0);
+  const buttonsRef = useRef<HTMLDivElement>(null);
 
   const cyclePose = (): void => {
     setPose((p) => (p === 'default' ? 'tpose' : p === 'tpose' ? 'walking' : 'default'));
@@ -26,6 +28,15 @@ export default function PreviewArea({ texture }: PreviewAreaProps): React.JSX.El
     link.click();
   };
 
+  useEffect(() => {
+    const measure = () => {
+      setOffset(buttonsRef.current?.offsetHeight ?? 0);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
+
   return (
     <section className="mb-4 md:mb-0 md:flex md:flex-col md:h-full p-4">
       <h2 className="text-xl font-bold mb-2 text-gray-700 flex items-center">
@@ -34,11 +45,16 @@ export default function PreviewArea({ texture }: PreviewAreaProps): React.JSX.El
 
       <div className="bg-gray-200 shadow-lg overflow-hidden pixel-border flex-grow h-full">
         <div className="flex justify-center items-center model-placeholder">
-          <ThreePreview texture={texture} pose={pose} showOverlay={showOverlay} />
+          <ThreePreview
+            texture={texture}
+            pose={pose}
+            showOverlay={showOverlay}
+            bottomOffset={offset}
+          />
         </div>
       </div>
 
-      <div className="mt-4 grid grid-cols-3 gap-2">
+      <div ref={buttonsRef} className="mt-4 grid grid-cols-3 gap-2">
         <button
           className="pixel-button bg-gray-200 hover:bg-gray-300 p-2 pixel-border transition-colors flex items-center justify-center"
           aria-label="Change character pose"

--- a/src/components/three/three-preview.tsx
+++ b/src/components/three/three-preview.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, { useEffect, useRef, useCallback, useState } from 'react';
 import * as THREE from 'three';
 import applyPose, { Pose } from './pose-utils';
 import createBox from './create-box';
@@ -21,17 +21,20 @@ interface ThreePreviewProps {
   texture: string | null;
   pose?: Pose;
   showOverlay?: boolean;
+  bottomOffset?: number;
 }
 
 export default function ThreePreview({
   texture,
   pose = 'default',
   showOverlay = true,
+  bottomOffset = 0,
 }: ThreePreviewProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer>();
   const cameraRef = useRef<THREE.PerspectiveCamera>();
   const rotationRef = useRef<number>(0);
+  const [containerHeight, setContainerHeight] = useState<number>(0);
 
   const armLRef = useRef<THREE.Mesh<THREE.BoxGeometry, THREE.MeshBasicMaterial[]> | null>(null);
   const armRRef = useRef<THREE.Mesh<THREE.BoxGeometry, THREE.MeshBasicMaterial[]> | null>(null);
@@ -202,13 +205,27 @@ export default function ThreePreview({
     });
   }, [showOverlay]);
 
+  useEffect(() => {
+    const updateHeight = () => {
+      const rect = containerRef.current?.getBoundingClientRect();
+      if (rect) {
+        const height = window.innerHeight - rect.top - bottomOffset;
+        setContainerHeight(height > 0 ? height : 0);
+      }
+    };
+
+    updateHeight();
+    window.addEventListener('resize', updateHeight);
+    return () => window.removeEventListener('resize', updateHeight);
+  }, [bottomOffset]);
+
   return (
     <div
       ref={containerRef}
       style={{
         width: '100%',
         minHeight: '200px',
-        height: '100%',
+        height: containerHeight ? `${containerHeight}px` : '100%',
         position: 'relative',
       }}
     />


### PR DESCRIPTION
## Summary
- allow ThreePreview to accept a bottom offset for resizing
- measure button area and provide offset to the preview
- update height calculation to reserve space for controls

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687faa7586388328be412cda7775ad60