### PR TITLE
Fix preview height offset for footer

### DIFF
--- a/src/components/myFooter.tsx
+++ b/src/components/myFooter.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 interface MyFooterProps {}
 
-const MyFooter: React.FC<MyFooterProps> = () => {
+const MyFooter = React.forwardRef<HTMLElement, MyFooterProps>((_props, ref) => {
   return (
-    <footer className="bg-gray-800 text-white py-4 px-4">
+    <footer ref={ref} className="bg-gray-800 text-white py-4 px-4">
       <div className="container mx-auto text-center text-sm">
         <p>© 2025 SkinCrafter. All rights reserved.</p>
         <div className="flex justify-center space-x-4 mt-2">
@@ -21,6 +21,6 @@ const MyFooter: React.FC<MyFooterProps> = () => {
       </div>
     </footer>
   );
-};
+});
 
 export default MyFooter;

--- a/src/components/previewArea.tsx
+++ b/src/components/previewArea.tsx
@@ -4,9 +4,10 @@ import type { Pose } from './three/pose-utils';
 
 interface PreviewAreaProps {
   texture: string | null;
+  footerHeight: number;
 }
 
-export default function PreviewArea({ texture }: PreviewAreaProps): React.JSX.Element {
+export default function PreviewArea({ texture, footerHeight }: PreviewAreaProps): React.JSX.Element {
   const [pose, setPose] = useState<Pose>('default');
   const [showOverlay, setShowOverlay] = useState<boolean>(true);
   const [offset, setOffset] = useState<number>(0);
@@ -30,12 +31,13 @@ export default function PreviewArea({ texture }: PreviewAreaProps): React.JSX.El
 
   useEffect(() => {
     const measure = () => {
-      setOffset(buttonsRef.current?.offsetHeight ?? 0);
+      const buttons = buttonsRef.current?.offsetHeight ?? 0;
+      setOffset(buttons + footerHeight);
     };
     measure();
     window.addEventListener('resize', measure);
     return () => window.removeEventListener('resize', measure);
-  }, []);
+  }, [footerHeight]);
 
   return (
     <section className="mb-4 md:mb-0 md:flex md:flex-col md:h-full p-4">

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 
 import { Race } from '../data/races';
 import NBar from '../components/nbar';
@@ -19,6 +19,8 @@ const App: React.FC = () => {
   const [hat, setHat] = useState<Hat>('None');
   const layerOrder: LayerOrder = defaultLayerOrder;
   const [combinedTexture, setCombinedTexture] = useState<string | null>(null);
+  const footerRef = useRef<HTMLElement>(null);
+  const [footerHeight, setFooterHeight] = useState<number>(0);
 
   const skinColors = useMemo(() => skinColorMap[race], [race]);
 
@@ -33,6 +35,15 @@ const App: React.FC = () => {
 
   const handleHatChange = useCallback((newHat: Hat) => {
     setHat(newHat);
+  }, []);
+
+  useEffect(() => {
+    const measure = () => {
+      setFooterHeight(footerRef.current?.offsetHeight ?? 0);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
   }, []);
 
   useEffect(() => {
@@ -54,7 +65,7 @@ const App: React.FC = () => {
 
       <div className="flex-1 flex flex-col md:flex-row gap-8">
         <div className="flex-1 w-full md:w-1/2">
-          <PreviewArea texture={combinedTexture} />
+          <PreviewArea texture={combinedTexture} footerHeight={footerHeight} />
         </div>
         <div className="flex-1 w-full md:w-1/2">
           <Wardrobe
@@ -67,7 +78,7 @@ const App: React.FC = () => {
         </div>
       </div>
 
-      <MyFooter />
+      <MyFooter ref={footerRef} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- forward footer ref to measure its height
- add footer height to preview offset calculation
- pass footer height from the app component

## Testing
- `npm install` *(fails: unable to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_687fae7896448328a7135461df35a671