### PR TITLE
Persist wardrobe selections using localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm run dev
 
 The app will be available at `http://localhost:5173` by default.
 Navigate to `/` for the wardrobe interface or `/mcskinview` to view skins from the Mojang API.
+The wardrobe remembers your last selected race, skin color and hat using `localStorage`.
 
 ## Loading a Minecraft skin
 

--- a/src/components/wardrobe-sections/WardrobeHat.tsx
+++ b/src/components/wardrobe-sections/WardrobeHat.tsx
@@ -1,50 +1,50 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { hats, Hat } from '../../data/hatTextureMap';
 
 export interface WardrobeHatProps {
+  selectedHat: Hat;
   onChange?: (hat: Hat) => void;
 }
 
-const WardrobeHat: React.FC<WardrobeHatProps> = React.memo(({ onChange }) => {
-  const [selectedHat, setSelectedHat] = useState<Hat>('None');
+const WardrobeHat: React.FC<WardrobeHatProps> = React.memo(
+  ({ selectedHat, onChange }) => {
+    const handleClick = useCallback(
+      (hat: Hat) => {
+        onChange?.(hat);
+      },
+      [onChange]
+    );
 
-  const handleClick = useCallback(
-    (hat: Hat) => {
-      setSelectedHat(hat);
-      onChange?.(hat);
-    },
-    [onChange]
-  );
-
-  return (
-    <div className="mb-4" role="group" aria-label="Select Hat">
-      <h3 className="mb-2 font-semibold">Hat</h3>
-      <div className="grid grid-cols-3 gap-2">
-        {hats.map((hat) => {
-          const isSelected = selectedHat === hat;
-          return (
-            <button
-              key={hat}
-              type="button"
-              className={`px-2 py-1 border rounded hover:bg-gray-200${
-                isSelected ? ' bg-blue-500 text-white' : ''
-              }`}
-              aria-pressed={isSelected}
-              onClick={() => handleClick(hat)}
-              onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleClick(hat);
-                }
-              }}
-            >
-              {hat}
-            </button>
-          );
-        })}
+    return (
+      <div className="mb-4" role="group" aria-label="Select Hat">
+        <h3 className="mb-2 font-semibold">Hat</h3>
+        <div className="grid grid-cols-3 gap-2">
+          {hats.map((hat) => {
+            const isSelected = selectedHat === hat;
+            return (
+              <button
+                key={hat}
+                type="button"
+                className={`px-2 py-1 border rounded hover:bg-gray-200${
+                  isSelected ? ' bg-blue-500 text-white' : ''
+                }`}
+                aria-pressed={isSelected}
+                onClick={() => handleClick(hat)}
+                onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleClick(hat);
+                  }
+                }}
+              >
+                {hat}
+              </button>
+            );
+          })}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 export default WardrobeHat;

--- a/src/components/wardrobe-sections/WardrobeRace.tsx
+++ b/src/components/wardrobe-sections/WardrobeRace.tsx
@@ -1,50 +1,50 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import races, { Race } from '../../data/races';
 
 export interface WardrobeRaceProps {
+  selectedRace: Race;
   onChange?: (race: Race) => void;
 }
 
-const WardrobeRace: React.FC<WardrobeRaceProps> = React.memo(({ onChange }) => {
-  const [selectedRace, setSelectedRace] = useState<Race>('Human');
+const WardrobeRace: React.FC<WardrobeRaceProps> = React.memo(
+  ({ selectedRace, onChange }) => {
+    const handleClick = useCallback(
+      (race: Race) => {
+        onChange?.(race);
+      },
+      [onChange]
+    );
 
-  const handleClick = useCallback(
-    (race: Race) => {
-      setSelectedRace(race);
-      onChange?.(race);
-    },
-    [onChange]
-  );
-
-  return (
-    <div className="mb-4" role="group" aria-label="Select Race">
-      <h3 className="mb-2 font-semibold">Race</h3>
-      <div className="grid grid-cols-3 gap-2">
-        {races.map((race) => {
-          const isSelected = selectedRace === race;
-          return (
-            <button
-              key={race}
-              type="button"
-              className={`px-2 py-1 border rounded hover:bg-gray-200${
-                isSelected ? ' bg-blue-500 text-white' : ''
-              }`}
-              aria-pressed={isSelected}
-              onClick={() => handleClick(race)}
-              onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleClick(race);
-                }
-              }}
-            >
-              {race}
-            </button>
-          );
-        })}
+    return (
+      <div className="mb-4" role="group" aria-label="Select Race">
+        <h3 className="mb-2 font-semibold">Race</h3>
+        <div className="grid grid-cols-3 gap-2">
+          {races.map((race) => {
+            const isSelected = selectedRace === race;
+            return (
+              <button
+                key={race}
+                type="button"
+                className={`px-2 py-1 border rounded hover:bg-gray-200${
+                  isSelected ? ' bg-blue-500 text-white' : ''
+                }`}
+                aria-pressed={isSelected}
+                onClick={() => handleClick(race)}
+                onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleClick(race);
+                  }
+                }}
+              >
+                {race}
+              </button>
+            );
+          })}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 
 export default WardrobeRace;

--- a/src/components/wardrobe.tsx
+++ b/src/components/wardrobe.tsx
@@ -10,6 +10,8 @@ import type { Hat } from '../data/hatTextureMap';
 interface WardrobeProps {
   skinColors: string[];
   selectedSkinColor: string | null;
+  selectedRace: Race;
+  selectedHat: Hat;
   onRaceChange?: (race: Race) => void;
   onSkinColorChange?: (color: string) => void;
   onHatChange?: (hat: Hat) => void;
@@ -18,13 +20,15 @@ interface WardrobeProps {
 export default function Wardrobe({
   skinColors,
   selectedSkinColor,
+  selectedRace,
+  selectedHat,
   onRaceChange,
   onSkinColorChange,
   onHatChange,
 }: WardrobeProps): React.JSX.Element {
   return (
     <div>
-      <WardrobeRace onChange={onRaceChange} />
+      <WardrobeRace selectedRace={selectedRace} onChange={onRaceChange} />
 
       <WardrobeSkinColor
         colors={skinColors}
@@ -32,7 +36,7 @@ export default function Wardrobe({
         onChange={onSkinColorChange}
       />
 
-      <WardrobeHat onChange={onHatChange} />
+      <WardrobeHat selectedHat={selectedHat} onChange={onHatChange} />
 
       <WardrobeEyes />
 

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 
-import { Race } from '../data/races';
+import races, { Race } from '../data/races';
 import NBar from '../components/nbar';
 import PreviewArea from '../components/previewArea';
 import Wardrobe from '../components/wardrobe';
@@ -9,7 +9,7 @@ import defaultLayerOrder from '../data/layerOrder';
 
 import skinColorMap from '../data/skinColorMap';
 import raceTextureMap from '../data/raceTextureMap';
-import hatTextureMap, { Hat } from '../data/hatTextureMap';
+import hatTextureMap, { Hat, hats } from '../data/hatTextureMap';
 import combineTextures from '../utils/combineTextures';
 import MyFooter from '../components/myFooter';
 
@@ -21,6 +21,27 @@ const App: React.FC = () => {
   const [combinedTexture, setCombinedTexture] = useState<string | null>(null);
   const footerRef = useRef<HTMLElement>(null);
   const [footerHeight, setFooterHeight] = useState<number>(0);
+
+  useEffect(() => {
+    const storedRace = localStorage.getItem('wardrobeRace');
+    let raceToSet: Race = 'Human';
+    if (storedRace && races.includes(storedRace as Race)) {
+      raceToSet = storedRace as Race;
+      setRace(raceToSet);
+    }
+
+    const storedColor = localStorage.getItem('wardrobeSkinColor');
+    if (storedColor && skinColorMap[raceToSet].includes(storedColor)) {
+      setSkinColor(storedColor);
+    } else {
+      setSkinColor(skinColorMap[raceToSet][0]);
+    }
+
+    const storedHat = localStorage.getItem('wardrobeHat');
+    if (storedHat && hats.includes(storedHat as Hat)) {
+      setHat(storedHat as Hat);
+    }
+  }, []);
 
   const skinColors = useMemo(() => skinColorMap[race], [race]);
 
@@ -36,6 +57,18 @@ const App: React.FC = () => {
   const handleHatChange = useCallback((newHat: Hat) => {
     setHat(newHat);
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem('wardrobeRace', race);
+  }, [race]);
+
+  useEffect(() => {
+    localStorage.setItem('wardrobeSkinColor', skinColor);
+  }, [skinColor]);
+
+  useEffect(() => {
+    localStorage.setItem('wardrobeHat', hat);
+  }, [hat]);
 
   useEffect(() => {
     const measure = () => {
@@ -71,6 +104,8 @@ const App: React.FC = () => {
           <Wardrobe
             skinColors={skinColors}
             selectedSkinColor={skinColor}
+            selectedRace={race}
+            selectedHat={hat}
             onRaceChange={handleRaceChange}
             onSkinColorChange={handleSkinColorChange}
             onHatChange={handleHatChange}


### PR DESCRIPTION
## Summary
- keep selected race/skin color/hat in `localStorage`
- update `Wardrobe` component to be controlled by `App`
- adapt `WardrobeRace` and `WardrobeHat` to accept selected values
- document new persistence behavior in README

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find type definition file for `vite/client`)*

------
https://chatgpt.com/codex/tasks/task_e_687fb1f7e9f08328aaaf411fcada8cce