### PR TITLE
Fix mobile layout for customization

### DIFF
--- a/src/components/wardrobe.tsx
+++ b/src/components/wardrobe.tsx
@@ -27,7 +27,7 @@ export default function Wardrobe({
   onHatChange,
 }: WardrobeProps): React.JSX.Element {
   return (
-    <section className="overflow-y-scroll mb-4 md:mb-0 md:flex md:flex-col md:h-full p-4 customization-panel">
+    <section className="overflow-visible md:overflow-y-scroll mb-4 md:mb-0 md:flex md:flex-col md:h-full p-4 customization-panel">
       <h2 className="text-xl font-bold mb-2 text-gray-700 flex items-center">
         <i className="fas fa-sliders mr-2 text-green-700" /> Customization
       </h2>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -124,6 +124,12 @@
 }
 
 .options-container {
-  max-height: calc(100vh - 240px);
-  overflow-y: auto;
+  overflow-y: visible;
+}
+
+@media (min-width: 768px) {
+  .options-container {
+    max-height: calc(100vh - 240px);
+    overflow-y: auto;
+  }
 }


### PR DESCRIPTION
## Summary
- remove scroll on wardrobe section for mobile screens
- update styles to show entire customization panel without scrolling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fbba27f6483289e491c86db2e3ceb