### PR TITLE
Fix wardrobe card shadows clipping

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -93,7 +93,7 @@ const App: React.FC = () => {
   }, [race, hat]);
 
   return (
-    <div className="max-w-full min-h-dvh md:h-screen overflow-hidden flex flex-col">
+    <div className="max-w-full min-h-dvh md:h-screen overflow-x-visible overflow-y-hidden flex flex-col">
       <NBar />
 
       <div className="flex-1 flex flex-col md:flex-row">


### PR DESCRIPTION
## Summary
- prevent clipping of wardrobe section shadows on the right side

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687fcdd72e388328aac6ff70ca464a36